### PR TITLE
Feat: Load billboard from backend and Cache new billboard categories

### DIFF
--- a/seu_lourival/lib/app/modules/billboard/controller.dart
+++ b/seu_lourival/lib/app/modules/billboard/controller.dart
@@ -15,6 +15,10 @@ class BillboardController extends GetxController {
     await _getStories();
   }
 
+  Future<void> reloadStories() async {
+    _getStories();
+  }
+
   Future<void> _getStories() async {
     isLoading.value = true;
     storyCategories.value = await _repository.getBillboardStories();
@@ -24,9 +28,13 @@ class BillboardController extends GetxController {
 
 class BillBoardModel {
   final String category;
-  final List<StoryModel> stories;
+  List<StoryModel> stories = [];
 
-  BillBoardModel({required this.category, required this.stories});
+  BillBoardModel({required this.category});
+
+  void addStory(StoryModel story) {
+    stories.add(story);
+  }
 }
 
 class StoryModel {

--- a/seu_lourival/lib/app/modules/billboard/new_billboard/binding.dart
+++ b/seu_lourival/lib/app/modules/billboard/new_billboard/binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/instance_manager.dart';
 import 'package:image_picker/image_picker.dart';
+import '../../../data/providers/billboard-category.provider.dart';
 import 'controller.dart';
 import 'repository.dart';
 
@@ -7,7 +8,7 @@ class NewBillboardBinding implements Bindings {
   @override
   void dependencies() {
     Get.put(NewBillboardController(
-      NewBillboardRepository(),
+      NewBillboardRepository(Get.find()),
       Get.find(),
     ));
   }

--- a/seu_lourival/lib/app/modules/billboard/new_billboard/controller.dart
+++ b/seu_lourival/lib/app/modules/billboard/new_billboard/controller.dart
@@ -34,6 +34,7 @@ class NewBillboardController extends GetxController {
   @override
   void onInit() async {
     isLoading = true;
+    print("CATEGORIAS: ${categories.isEmpty}");
     categories = await _repository.getCategories();
     isLoading = false;
     super.onInit();

--- a/seu_lourival/lib/app/modules/billboard/new_billboard/repository.dart
+++ b/seu_lourival/lib/app/modules/billboard/new_billboard/repository.dart
@@ -8,7 +8,9 @@ class NewBillboardRepository {
   final _storage = FirebaseStorage.instance;
   final categoryCollection = "categories-billboard";
   final billboardCollection = "billboards";
-  final _categoryProvider = BillboardCategoryProvider();
+  final BillboardCategoryProvider _categoryProvider;
+
+  NewBillboardRepository(this._categoryProvider);
 
   Future<List<String>> getCategories() async {
     return await _categoryProvider.getBillboardCategories();

--- a/seu_lourival/lib/app/modules/billboard/page.dart
+++ b/seu_lourival/lib/app/modules/billboard/page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:seu_lourival/app/data/models/user_model.dart';
+import 'package:seu_lourival/app/data/providers/billboard-category.provider.dart';
 import 'package:seu_lourival/app/data/services/user_service.dart';
 import 'package:seu_lourival/app/modules/billboard/widgets/custom_story_view.dart';
 import 'package:seu_lourival/core/values/colors.dart';
@@ -22,9 +23,10 @@ class BillboardPage extends StatelessWidget {
       floatingActionButton: Get.find<UserService>().user?.type == UserType.ADMIN
           ? FloatingActionButton(
               onPressed: () {
+                Get.put(BillboardCategoryProvider());
                 Get.toNamed(Routes.newBillboard);
               },
-              child: Icon(Icons.add),
+              child: const Icon(Icons.add),
             )
           : null,
       body: Obx(

--- a/seu_lourival/lib/app/modules/billboard/page.dart
+++ b/seu_lourival/lib/app/modules/billboard/page.dart
@@ -34,47 +34,52 @@ class BillboardPage extends StatelessWidget {
             ? const Center(
                 child: CircularProgressIndicator(),
               )
-            : ListView.separated(
-                itemBuilder: (context, index) {
-                  final model = _controller.storyCategories[index];
-                  final url = model.stories.first.url;
-                  final caption = model.stories.first.caption;
-                  return Card(
-                    elevation: 5,
-                    child: ListTile(
-                        contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 16),
-                        leading: url != null
-                            ? CircleAvatar(
-                                backgroundImage: NetworkImage(url),
-                              )
-                            : const Icon(Icons.camera_alt_outlined),
-                        trailing: CircleAvatar(
-                          backgroundColor: DSColors.tertiary,
-                          radius: 12,
-                          child: DSText.sm(
-                            model.stories.length.toString(),
-                          ),
-                        ),
-                        title: Text(model.category),
-                        subtitle: caption != null
-                            ? Text(
-                                caption,
-                                maxLines: 3,
-                              )
-                            : null,
-                        onTap: () {
-                          Get.to(CustomStoryView(
-                            _controller.storyController,
-                            stories: model.stories,
-                            title: model.category,
-                          ));
-                        }),
-                  );
+            : RefreshIndicator(
+                onRefresh: () async {
+                  _controller.reloadStories();
                 },
-                separatorBuilder: (context, index) => const Divider(),
-                padding: const EdgeInsets.all(8),
-                itemCount: _controller.storyCategories.length,
+                child: ListView.separated(
+                  itemBuilder: (context, index) {
+                    final model = _controller.storyCategories[index];
+                    final url = model.stories.first.url;
+                    final caption = model.stories.first.caption;
+                    return Card(
+                      elevation: 5,
+                      child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 16),
+                          leading: url != null
+                              ? CircleAvatar(
+                                  backgroundImage: NetworkImage(url),
+                                )
+                              : const Icon(Icons.camera_alt_outlined),
+                          trailing: CircleAvatar(
+                            backgroundColor: DSColors.tertiary,
+                            radius: 12,
+                            child: DSText.sm(
+                              model.stories?.length.toString() ?? "",
+                            ),
+                          ),
+                          title: Text(model.category),
+                          subtitle: caption != null
+                              ? Text(
+                                  caption,
+                                  maxLines: 3,
+                                )
+                              : null,
+                          onTap: () {
+                            Get.to(CustomStoryView(
+                              _controller.storyController,
+                              stories: model.stories ?? [],
+                              title: model.category,
+                            ));
+                          }),
+                    );
+                  },
+                  separatorBuilder: (context, index) => const Divider(),
+                  padding: const EdgeInsets.all(8),
+                  itemCount: _controller.storyCategories.length,
+                ),
               ),
       ),
     );

--- a/seu_lourival/lib/app/modules/billboard/repository.dart
+++ b/seu_lourival/lib/app/modules/billboard/repository.dart
@@ -1,43 +1,41 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get/get.dart';
 import 'package:seu_lourival/app/modules/billboard/controller.dart';
 import 'package:story_view/story_view.dart';
 
 class BillboardRepository {
-//  todo: implement BillboardRepository methods;
+  final _firestore = FirebaseFirestore.instance;
+  final billboardCollection = "billboards";
 
   Future<List<BillBoardModel>> getBillboardStories() async {
-    final stories = <BillBoardModel>[
-      BillBoardModel(category: "Financeiro", stories: [
-        StoryModel(
-          caption:
-              "Lembrando que teremos um aumento no valor da taxa de condomínio a partir de 10/10/2022. Lembrando que teremos um aumento no valor da taxa de condomínio a partir de 10/10/2022. Lembrando que teremos um aumento no valor da taxa de condomínio a partir de 10/10/2022. Lembrando que teremos um aumento no valor da taxa de condomínio a partir de 10/10/2022",
-        ),
-      ]),
-      BillBoardModel(category: "Manutenção", stories: [
-        StoryModel(
-            caption:
-                "Nosso elevador entrará em manutenção na noite de hoje (15/10)"),
-        StoryModel(
-          caption:
-              "Interfone do bloco D está fora de serviço. Já estamos solicitando reparos",
-        ),
-      ]),
-      BillBoardModel(category: "Aniversários", stories: [
-        StoryModel(
-          caption:
-              "Bryan, morador do 405 - Bloco C está comemorando mais um ano de vida",
-          url:
-              "https://cf.shopee.com.br/file/38a45adbe0c39333138ff6f0b4f143b2_tn",
-        ),
-        StoryModel(
-          caption:
-              "Lays, moradora do 102 - Bloco C está comemorando mais um ano de vida",
-          url:
-              "https://play-lh.googleusercontent.com/IQ085_7QBCcNe4HKklLxqNmDC2CpHik38fL0GCn_X00Mdm1C2m4JYuMbKn9PuTAdIxU",
-        ),
-      ]),
-    ];
-    await Future.delayed(2.seconds);
-    return stories;
+    final categories = <String>[];
+    final result = await _firestore
+        .collection(billboardCollection)
+        .orderBy("category")
+        .get();
+    final stories = result.docs.map((doc) {
+      final data = doc.data();
+      final model = StoryModel(
+        caption: data["caption"],
+        url: data["url"],
+        category: data["category"],
+        id: doc.id,
+      );
+      categories.addIf(
+          !categories.contains(model.category), model.category ?? "");
+      return model;
+    }).toList();
+
+    final models = <BillBoardModel>[];
+    categories.forEach((cat) {
+      final bb = BillBoardModel(category: cat);
+      stories.forEach((sto) {
+        if (sto.category == cat) {
+          bb.addStory(sto);
+        }
+      });
+      models.add(bb);
+    });
+    return models;
   }
 }


### PR DESCRIPTION
## Descrição
- Injeta o provider das categorias dos manifestos antes da tela de novo comunicado ser criada, permitindo cachear em tempo de execução as categorias do banco de dados
- Carrega os dados dos comunicados a partir do backend, listando por categoria
- Adicionado pull to refresh para dar reload nos comunicados

---

## Tipo da alteração

feat: Uma nova funcionalidade
fix: Correção de algum bug

<!-- USE A OPÇÃO MAIS RELEVANTE
feat: Uma nova funcionalidade
fix: Correção de algum bug
style: Alterações que não afetam o significado do código (espaço em branco, formatação etc.)
perf: Mudança no código para melhoria de performance
refactor: Uma alteração de código que não corrige um bug nem adiciona um recurso
test: Adicionando testes ausentes ou corrigindo testes existentes
build: Alterações que afetam o sistema de compilação ou dependências externas
ci: Alterações nos arquivos e scripts de configuração do CI'
chore: Outras alterações que não modificam os arquivos de origem ou de teste
docs: Apenas mudança de documentação
revert: Reverte um commit
wip: Código em desenvolvimento
-->

---
